### PR TITLE
Update canonical link and title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>BSII's bbeat player</title>
-	<link rel="canonical" href="https://bsquareii.github.io/BSquare_BytebeatComposer">
+        <title>Gigorthub's Bytebeat Composer</title>
+        <link rel="canonical" href="https://Gigorthub.github.io/Gigorthub_BytebeatComposer">
 	<link rel="shortcut icon" href="favicon.png">
 	<link rel="stylesheet" type="text/css" href="bytebeat.css?version=2023022000">
 	<link rel="modulepreload" href="./scripts/audioProcessor.mjs?version=2023022000">


### PR DESCRIPTION
## Summary
- Point canonical URL to `Gigorthub_BytebeatComposer` site
- Rename page title to "Gigorthub's Bytebeat Composer"

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4b24ac8248331a04c07149aa9639e